### PR TITLE
rename "resources" folder to "res" folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 <div align="center"> 
 <h1> Android-XML-Editor </h1> </div>
-<p align="center"> Editor for Android XML files in VSCode powered by TotalCross </strong></em></p>
+<p align="center">Fork of <a href=https://github.com/Knowcode-AI/android-xml-editor>Knowcode-AI/android-xml-editor</a> that works.<br>It consists in an editor for Android XML files in VSCode powered by TotalCross</p>
 
 <div align="center">
   <span>&nbsp;&nbsp;•&nbsp;&nbsp;</span>

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -64,7 +64,7 @@ class AppPanel {
 
 		const fse = require('fs-extra');
 		//@ts-ignore.
-		var sourceDir = path.join(rootUri?.path, "src/main/resources/drawable")
+		var sourceDir = path.join(rootUri?.path, "src/main/res/drawable")
 		var destinationDir = path.join(extensionUri.path, "/media/drawable")
 		fs.rmdirSync(destinationDir, { recursive: true });
 


### PR DESCRIPTION
Android resources files should be called `res`. I fixed and now it shoudl work with gradle projects.