### PR TITLE
Addressing issue #6, making assets location user-configurable via a n…

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
+ 1 Closed
+Author 
+Label 
+Projects  Milestones 
+Assignee 
+Sort Issues list
+Assets (& cache) location should be user configurable
+#6 opened 16 hours ago by Nos78
 
 <div align="center"> <img src="https://i.imgur.com/zcQ1Z6r.png" alt="android and totalcross logo together" width="150" height="150"/> </div>
 
@@ -29,8 +37,13 @@ Extension that interprets the XML file - transforming it into HTML - and display
 
 ## 🚨 Requirements
 * VS Code 1.47+;
-* All images and media (assets) must be in this `src/main/resources/drawable` directory;
+* By default, the plugin looks for images and media (assets) in this `src/main/res/drawable` directory;
 * **As this is an alpha version, the plugin only supports `content-layout`**.
+
+
+**NEW:** Resources Path now user-configurable
+* The assets location can now be configured at the user (all workspaces) or per-workspace level by using vscode *File->Settings*, and navigating to *Android XML Editor* within the extensions tab. The new path should be relative to the workspace root. VSCode workspace settings override any user setting.
+* **Example:** A workspace opened at `~/src/android/helloWorld/` contains the default android project sub-directories. The workspace resources path setting would need to be `app/src/main./res/drawable`
 
 ## 👩‍💻 Using Android-XML-Editor plugin
 

--- a/package.json
+++ b/package.json
@@ -20,6 +20,18 @@
 	},
 	"main": "./out/extension.js",
 	"contributes": {
+		"configuration": {
+			"type": "object",
+			"title": "Android XML Editor",
+			"properties": {
+				"xmlEditor.resourcesPath": {
+					"type": "string",
+					"default": "src/main/res/drawable",
+					"markdownDescription": "The location of project assets (**I.E.** *images & media*), relative to the root of the open workspace.\n\nThe default location is `src/main/res/drawable`",
+					"order": 1
+				}
+			}
+		},
 		"configurationDefaults": {
 			"[xml]": {
 				"editor.mouseWheelZoom": true

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -68,12 +68,17 @@ class AppPanel {
 			// fall back to hard-coded path
 			resourcesPath = "src/main/res/drawable";
 		}
+		
 		const fse = require('fs-extra');
 		//@ts-ignore.
 		var sourceDir = path.join(rootUri?.path, resourcesPath)
 		var destinationDir = path.join(extensionUri.path, "/media/drawable")
-		fs.rmdirSync(destinationDir, { recursive: true });
-
+		if (fs.existsSync(destinationDir)) {
+			fs.rmdirSync(destinationDir, { recursive: true });
+		} else {
+			// Create cache location
+			fs.mkdirSync(destinationDir, { recursive: true });
+		}
 		// To copy a folder or file  
 		fse.copySync(sourceDir, destinationDir)
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -62,9 +62,15 @@ class AppPanel {
 		let workspaceFolder = vscode.workspace.getWorkspaceFolder(editor.document.uri);
 		let rootUri = workspaceFolder?.uri
 
+		let extensionConfig = vscode.workspace.getConfiguration('xmlEditor');
+		let resourcesPath = extensionConfig?.resourcesPath;
+		if(!resourcesPath || resourcesPath == "") {
+			// fall back to hard-coded path
+			resourcesPath = "src/main/res/drawable";
+		}
 		const fse = require('fs-extra');
 		//@ts-ignore.
-		var sourceDir = path.join(rootUri?.path, "src/main/resources/drawable")
+		var sourceDir = path.join(rootUri?.path, resourcesPath)
 		var destinationDir = path.join(extensionUri.path, "/media/drawable")
 		fs.rmdirSync(destinationDir, { recursive: true });
 


### PR DESCRIPTION
Added new configuration setting, xmlEditor.resourcesPath, which is accessible via the File->Settings menu within VSCode, under the extensions tab, with the title "Android XML Editor".

package.json:
Add new configuration properties for xmlEditor.resourcesPath, as a string with a default value to match the existing hard-coded location (modified to reflect the standard location of /res/ rather than /resources/).

Added a markdownDescription for this setting, which explains the default value and that this path is relative to the workspace root.

Note that when you add settings (or remove them) into an extension package.json, you need to reboot vscode to re-build the settings menu, then reboot vscode a second time to actually see it.

src/extension.ts:
+ Modified the createOrShow() function to get the configuration via vscode API, and get the resources path from the settings configuration object. If this path is not defined or empty, we fall back to the (modified) hard-coded path.
+ Replaced the hard-coded path with the new variable from the settings.

This commit addresses issue #6 , change 1. This pull request also factors in the change/pull request submitted by EduApps-CDG that addressed issue #4 